### PR TITLE
Implement multiple-item sales with receipt

### DIFF
--- a/inventario/templates/nueva_venta.html
+++ b/inventario/templates/nueva_venta.html
@@ -2,22 +2,80 @@
 {% block title %}Nueva Venta{% endblock %}
 {% block content %}
 <h2 class="mb-3">Nueva Venta</h2>
-<form method="post">
+
+<form method="post" id="venta-form">
   <div class="row">
     <div class="col-md-6 mb-3">
       <label class="form-label">Producto</label>
-      <select name="producto_id" class="form-select" required>
+      <select id="producto" class="form-select">
         {% for p in productos %}
-        <option value="{{ p.id }}">{{ p.nombre }} ({{ p.cantidad }})</option>
+        <option value="{{ p.id }}" data-precio="{{ p.precio }}" data-colegio="{{ p.colegio }}">{{ p.nombre }} ({{ p.cantidad }})</option>
         {% endfor %}
       </select>
     </div>
-    <div class="col-md-6 mb-3">
+    <div class="col-md-4 mb-3">
       <label class="form-label">Cantidad</label>
-      <input type="number" name="cantidad" class="form-control" required>
+      <input type="number" id="cantidad" class="form-control">
+    </div>
+    <div class="col-md-2 mb-3 d-flex align-items-end">
+      <button class="btn btn-secondary w-100" id="add-btn">Añadir</button>
     </div>
   </div>
-  <button type="submit" class="btn btn-primary">Registrar</button>
-  <a href="{{ url_for('dashboard') }}" class="btn btn-secondary">Cancelar</a>
+
+  <table class="table table-striped mt-4">
+    <thead>
+      <tr>
+        <th>Prenda</th>
+        <th>Colegio</th>
+        <th>Cantidad</th>
+        <th>Precio</th>
+        <th>Subtotal</th>
+      </tr>
+    </thead>
+    <tbody id="lista-venta"></tbody>
+  </table>
+
+  <h4 class="mt-3">Total: $<span id="total">0.00</span></h4>
+
+  <input type="hidden" name="items" id="items">
+  <button type="submit" class="btn btn-primary mt-3">Registrar</button>
+  <a href="{{ url_for('dashboard') }}" class="btn btn-secondary mt-3">Cancelar</a>
 </form>
+
+<script>
+const productos = {{ productos | tojson }};
+let items = [];
+
+function actualizarTotal() {
+  let total = 0;
+  items.forEach(i => {
+    const prod = productos.find(p => p.id == i.id);
+    total += prod.precio * i.cantidad;
+  });
+  document.getElementById('total').innerText = total.toFixed(2);
+  document.getElementById('items').value = JSON.stringify(items);
+}
+
+document.getElementById('add-btn').addEventListener('click', function(e) {
+  e.preventDefault();
+  const id = document.getElementById('producto').value;
+  const cantidad = parseInt(document.getElementById('cantidad').value);
+  if (!id || !cantidad) return;
+  const prod = productos.find(p => p.id == id);
+  const subtotal = prod.precio * cantidad;
+
+  const tbody = document.getElementById('lista-venta');
+  const row = document.createElement('tr');
+  row.innerHTML = `<td>${prod.nombre}</td><td>${prod.colegio}</td><td>${cantidad}</td><td>${prod.precio.toFixed(2)}</td><td>${subtotal.toFixed(2)}</td>`;
+  tbody.appendChild(row);
+
+  items.push({id: id, cantidad: cantidad});
+  actualizarTotal();
+  document.getElementById('cantidad').value = '';
+});
+
+document.getElementById('venta-form').addEventListener('submit', function() {
+  actualizarTotal();
+});
+</script>
 {% endblock %}

--- a/inventario/templates/recibo_venta.html
+++ b/inventario/templates/recibo_venta.html
@@ -1,0 +1,29 @@
+{% extends 'base.html' %}
+{% block title %}Recibo de Venta{% endblock %}
+{% block content %}
+<h2 class="mb-3">Recibo de Venta</h2>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>Prenda</th>
+      <th>Colegio</th>
+      <th>Cantidad</th>
+      <th>Precio</th>
+      <th>Subtotal</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for v in ventas %}
+    <tr>
+      <td>{{ v.nombre }}</td>
+      <td>{{ v.colegio }}</td>
+      <td>{{ v.cantidad }}</td>
+      <td>{{ '%.2f'|format(v.precio) }}</td>
+      <td>{{ '%.2f'|format(v.subtotal) }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+<h4>Total: ${{ '%.2f'|format(total) }}</h4>
+<a href="{{ url_for('dashboard') }}" class="btn btn-primary mt-3">Aceptar</a>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a new receipt page
- allow adding many products in `nueva_venta`
- handle multiple-item sales server-side

## Testing
- `python -m py_compile inventario/app_flask_inventario.py`

------
https://chatgpt.com/codex/tasks/task_e_6877141f37c88330b2f57da578f30388