### PR TITLE
Add school and client CRUD

### DIFF
--- a/inventario/app_flask_inventario.py
+++ b/inventario/app_flask_inventario.py
@@ -299,5 +299,146 @@ def nueva_venta():
     conn.close()
     return render_template("nueva_venta.html", productos=productos, colegios=colegios)
 
+# --- CRUD Colegios ---
+
+@app.route('/colegios')
+def listar_colegios():
+    if 'user' not in session:
+        return redirect(url_for('login'))
+    conn = get_db()
+    cursor = conn.cursor(dictionary=True)
+    cursor.execute("SELECT * FROM colegios")
+    colegios = cursor.fetchall()
+    conn.close()
+    return render_template('colegios.html', colegios=colegios)
+
+
+@app.route('/colegios/crear', methods=['POST'])
+def crear_colegio():
+    if 'user' not in session:
+        return redirect(url_for('login'))
+    nombre = request.form['nombre']
+    direccion = request.form['direccion']
+    telefono = request.form['telefono']
+    contacto = request.form['contacto']
+    conn = get_db()
+    cursor = conn.cursor()
+    cursor.execute(
+        "INSERT INTO colegios(nombre, direccion, telefono, contacto) VALUES (%s, %s, %s, %s)",
+        (nombre, direccion, telefono, contacto))
+    conn.commit()
+    conn.close()
+    flash('Colegio creado correctamente')
+    return redirect(url_for('listar_colegios'))
+
+
+@app.route('/colegios/editar/<int:id>', methods=['GET', 'POST'])
+def editar_colegio(id):
+    if 'user' not in session:
+        return redirect(url_for('login'))
+    conn = get_db()
+    cursor = conn.cursor(dictionary=True)
+    if request.method == 'POST':
+        nombre = request.form['nombre']
+        direccion = request.form['direccion']
+        telefono = request.form['telefono']
+        contacto = request.form['contacto']
+        cursor.execute(
+            "UPDATE colegios SET nombre=%s, direccion=%s, telefono=%s, contacto=%s WHERE id=%s",
+            (nombre, direccion, telefono, contacto, id))
+        conn.commit()
+        conn.close()
+        flash('Colegio actualizado')
+        return redirect(url_for('listar_colegios'))
+    cursor.execute("SELECT * FROM colegios WHERE id=%s", (id,))
+    colegio = cursor.fetchone()
+    conn.close()
+    return render_template('editar_colegio.html', colegio=colegio)
+
+
+@app.route('/colegios/borrar/<int:id>', methods=['POST'])
+def eliminar_colegio(id):
+    if 'user' not in session:
+        return redirect(url_for('login'))
+    conn = get_db()
+    cursor = conn.cursor()
+    cursor.execute("DELETE FROM colegios WHERE id=%s", (id,))
+    conn.commit()
+    conn.close()
+    flash('Colegio eliminado')
+    return redirect(url_for('listar_colegios'))
+
+
+# --- CRUD Clientes ---
+
+@app.route('/clientes')
+def listar_clientes():
+    if 'user' not in session:
+        return redirect(url_for('login'))
+    conn = get_db()
+    cursor = conn.cursor(dictionary=True)
+    cursor.execute("SELECT * FROM clientes")
+    clientes = cursor.fetchall()
+    conn.close()
+    return render_template('clientes.html', clientes=clientes)
+
+
+@app.route('/clientes/crear', methods=['POST'])
+def crear_cliente():
+    if 'user' not in session:
+        return redirect(url_for('login'))
+    nombre = request.form['nombre']
+    apellido = request.form['apellido']
+    cedula = request.form['cedula']
+    telefono = request.form.get('telefono')
+    email = request.form.get('email')
+    conn = get_db()
+    cursor = conn.cursor()
+    cursor.execute(
+        "INSERT INTO clientes(nombre, apellido, cedula, telefono, email) VALUES (%s, %s, %s, %s, %s)",
+        (nombre, apellido, cedula, telefono, email))
+    conn.commit()
+    conn.close()
+    flash('Cliente creado correctamente')
+    return redirect(url_for('listar_clientes'))
+
+
+@app.route('/clientes/editar/<int:id>', methods=['GET', 'POST'])
+def editar_cliente(id):
+    if 'user' not in session:
+        return redirect(url_for('login'))
+    conn = get_db()
+    cursor = conn.cursor(dictionary=True)
+    if request.method == 'POST':
+        nombre = request.form['nombre']
+        apellido = request.form['apellido']
+        cedula = request.form['cedula']
+        telefono = request.form.get('telefono')
+        email = request.form.get('email')
+        cursor.execute(
+            """UPDATE clientes SET nombre=%s, apellido=%s, cedula=%s, telefono=%s, email=%s WHERE id=%s""",
+            (nombre, apellido, cedula, telefono, email, id))
+        conn.commit()
+        conn.close()
+        flash('Cliente actualizado')
+        return redirect(url_for('listar_clientes'))
+    cursor.execute("SELECT * FROM clientes WHERE id=%s", (id,))
+    cliente = cursor.fetchone()
+    conn.close()
+    return render_template('editar_cliente.html', cliente=cliente)
+
+
+@app.route('/clientes/borrar/<int:id>', methods=['POST'])
+def eliminar_cliente(id):
+    if 'user' not in session:
+        return redirect(url_for('login'))
+    conn = get_db()
+    cursor = conn.cursor()
+    cursor.execute("DELETE FROM clientes WHERE id=%s", (id,))
+    conn.commit()
+    conn.close()
+    flash('Cliente eliminado')
+    return redirect(url_for('listar_clientes'))
+
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000, debug=True)

--- a/inventario/templates/base.html
+++ b/inventario/templates/base.html
@@ -32,6 +32,12 @@
         <li class="nav-item">
           <a class="nav-link" href="{{ url_for('reporte_ventas') }}">Reportes</a>
         </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('listar_colegios') }}">Colegios</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('listar_clientes') }}">Clientes</a>
+        </li>
         {% if session.get('role') == 'admin' %}
         <li class="nav-item">
           <a class="nav-link" href="{{ url_for('gestionar_usuarios') }}">Usuarios</a>

--- a/inventario/templates/clientes.html
+++ b/inventario/templates/clientes.html
@@ -1,0 +1,61 @@
+{% extends 'base.html' %}
+{% block title %}Clientes{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between mb-3">
+  <h2>Clientes</h2>
+</div>
+<table class="table table-striped mb-4">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Nombre</th>
+      <th>Apellido</th>
+      <th>Cédula</th>
+      <th>Teléfono</th>
+      <th>Email</th>
+      <th>Acciones</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for c in clientes %}
+    <tr>
+      <td>{{ c.id }}</td>
+      <td>{{ c.nombre }}</td>
+      <td>{{ c.apellido }}</td>
+      <td>{{ c.cedula }}</td>
+      <td>{{ c.telefono }}</td>
+      <td>{{ c.email }}</td>
+      <td>
+        <a href="{{ url_for('editar_cliente', id=c.id) }}" class="btn btn-sm btn-primary">Editar</a>
+        <form action="{{ url_for('eliminar_cliente', id=c.id) }}" method="post" class="d-inline">
+          <button class="btn btn-sm btn-danger" onclick="return confirm('¿Eliminar?')">Eliminar</button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+<h3>Crear nuevo cliente</h3>
+<form method="post" action="{{ url_for('crear_cliente') }}">
+  <div class="row">
+    <div class="col-md-2 mb-3">
+      <input type="text" name="nombre" class="form-control" placeholder="Nombre" required>
+    </div>
+    <div class="col-md-2 mb-3">
+      <input type="text" name="apellido" class="form-control" placeholder="Apellido" required>
+    </div>
+    <div class="col-md-2 mb-3">
+      <input type="text" name="cedula" class="form-control" placeholder="Cédula" required>
+    </div>
+    <div class="col-md-2 mb-3">
+      <input type="text" name="telefono" class="form-control" placeholder="Teléfono">
+    </div>
+    <div class="col-md-3 mb-3">
+      <input type="email" name="email" class="form-control" placeholder="Email">
+    </div>
+    <div class="col-md-1 mb-3">
+      <button type="submit" class="btn btn-primary">Crear</button>
+    </div>
+  </div>
+</form>
+{% endblock %}

--- a/inventario/templates/colegios.html
+++ b/inventario/templates/colegios.html
@@ -1,0 +1,56 @@
+{% extends 'base.html' %}
+{% block title %}Colegios{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between mb-3">
+  <h2>Colegios</h2>
+</div>
+<table class="table table-striped mb-4">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Nombre</th>
+      <th>Dirección</th>
+      <th>Teléfono</th>
+      <th>Contacto</th>
+      <th>Acciones</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for c in colegios %}
+    <tr>
+      <td>{{ c.id }}</td>
+      <td>{{ c.nombre }}</td>
+      <td>{{ c.direccion }}</td>
+      <td>{{ c.telefono }}</td>
+      <td>{{ c.contacto }}</td>
+      <td>
+        <a href="{{ url_for('editar_colegio', id=c.id) }}" class="btn btn-sm btn-primary">Editar</a>
+        <form action="{{ url_for('eliminar_colegio', id=c.id) }}" method="post" class="d-inline">
+          <button class="btn btn-sm btn-danger" onclick="return confirm('¿Eliminar?')">Eliminar</button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+<h3>Crear nuevo colegio</h3>
+<form method="post" action="{{ url_for('crear_colegio') }}">
+  <div class="row">
+    <div class="col-md-3 mb-3">
+      <input type="text" name="nombre" class="form-control" placeholder="Nombre" required>
+    </div>
+    <div class="col-md-3 mb-3">
+      <input type="text" name="direccion" class="form-control" placeholder="Dirección" required>
+    </div>
+    <div class="col-md-3 mb-3">
+      <input type="text" name="telefono" class="form-control" placeholder="Teléfono" required>
+    </div>
+    <div class="col-md-2 mb-3">
+      <input type="text" name="contacto" class="form-control" placeholder="Contacto" required>
+    </div>
+    <div class="col-md-1 mb-3">
+      <button type="submit" class="btn btn-primary">Crear</button>
+    </div>
+  </div>
+</form>
+{% endblock %}

--- a/inventario/templates/editar_cliente.html
+++ b/inventario/templates/editar_cliente.html
@@ -1,0 +1,29 @@
+{% extends 'base.html' %}
+{% block title %}Editar Cliente{% endblock %}
+{% block content %}
+<h2 class="mb-3">Editar Cliente</h2>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Nombre</label>
+    <input type="text" class="form-control" name="nombre" value="{{ cliente.nombre }}" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Apellido</label>
+    <input type="text" class="form-control" name="apellido" value="{{ cliente.apellido }}" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Cédula</label>
+    <input type="text" class="form-control" name="cedula" value="{{ cliente.cedula }}" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Teléfono</label>
+    <input type="text" class="form-control" name="telefono" value="{{ cliente.telefono }}">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Email</label>
+    <input type="email" class="form-control" name="email" value="{{ cliente.email }}">
+  </div>
+  <button type="submit" class="btn btn-primary">Guardar</button>
+  <a href="{{ url_for('listar_clientes') }}" class="btn btn-secondary">Cancelar</a>
+</form>
+{% endblock %}

--- a/inventario/templates/editar_colegio.html
+++ b/inventario/templates/editar_colegio.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+{% block title %}Editar Colegio{% endblock %}
+{% block content %}
+<h2 class="mb-3">Editar Colegio</h2>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Nombre</label>
+    <input type="text" class="form-control" name="nombre" value="{{ colegio.nombre }}" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Dirección</label>
+    <input type="text" class="form-control" name="direccion" value="{{ colegio.direccion }}" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Teléfono</label>
+    <input type="text" class="form-control" name="telefono" value="{{ colegio.telefono }}" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Contacto</label>
+    <input type="text" class="form-control" name="contacto" value="{{ colegio.contacto }}" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Guardar</button>
+  <a href="{{ url_for('listar_colegios') }}" class="btn btn-secondary">Cancelar</a>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- include Colegios and Clientes in navigation
- add templates for managing schools and clients
- implement CRUD routes for colegios and clientes

## Testing
- `python -m py_compile inventario/app_flask_inventario.py`

------
https://chatgpt.com/codex/tasks/task_e_6877327baf3083309c4c47c8a3cecfad