### PR TITLE
Implement VAT and PDF receipt

### DIFF
--- a/inventario/templates/nueva_venta.html
+++ b/inventario/templates/nueva_venta.html
@@ -40,8 +40,13 @@
     </thead>
     <tbody id="lista-venta"></tbody>
   </table>
-
-  <h4 class="mt-3">Total: $<span id="total">0.00</span></h4>
+  <h4 class="mt-3">Subtotal: $<span id="total">0.00</span></h4>
+  <div class="form-check mt-2">
+    <input class="form-check-input" type="checkbox" id="aplicar_iva" name="aplicar_iva">
+    <label class="form-check-label" for="aplicar_iva">Incluir IVA 19%</label>
+  </div>
+  <h4 class="mt-3">IVA: $<span id="iva">0.00</span></h4>
+  <h4>Total con IVA: $<span id="total-final">0.00</span></h4>
 
   <input type="hidden" name="items" id="items">
   <button type="submit" class="btn btn-primary mt-3">Registrar</button>
@@ -78,7 +83,12 @@ function actualizarTotal() {
     const prod = productos.find(p => p.id == i.id);
     total += prod.precio * i.cantidad;
   });
+  const aplicarIVA = document.getElementById('aplicar_iva').checked;
+  const iva = aplicarIVA ? total * 0.19 : 0;
+  const totalFinal = total + iva;
   document.getElementById('total').innerText = total.toFixed(2);
+  document.getElementById('iva').innerText = iva.toFixed(2);
+  document.getElementById('total-final').innerText = totalFinal.toFixed(2);
   document.getElementById('items').value = JSON.stringify(items);
 }
 
@@ -103,5 +113,6 @@ document.getElementById('add-btn').addEventListener('click', function(e) {
 document.getElementById('venta-form').addEventListener('submit', function() {
   actualizarTotal();
 });
+document.getElementById('aplicar_iva').addEventListener('change', actualizarTotal);
 </script>
 {% endblock %}

--- a/inventario/templates/recibo_venta.html
+++ b/inventario/templates/recibo_venta.html
@@ -24,6 +24,13 @@
     {% endfor %}
   </tbody>
 </table>
+<h4>Subtotal: ${{ '%.2f'|format(total) }}</h4>
+{% if aplicar_iva %}
+<h4>IVA (19%): ${{ '%.2f'|format(iva) }}</h4>
+<h4>Total: ${{ '%.2f'|format(total_final) }}</h4>
+{% else %}
 <h4>Total: ${{ '%.2f'|format(total) }}</h4>
+{% endif %}
+<a href="{{ url_for('recibo_pdf') }}" class="btn btn-secondary mt-3">Descargar PDF</a>
 <a href="{{ url_for('dashboard') }}" class="btn btn-primary mt-3">Aceptar</a>
 {% endblock %}

--- a/inventario/templates/recibo_venta_pdf.html
+++ b/inventario/templates/recibo_venta_pdf.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<style>
+body { font-family: Arial, sans-serif; }
+table { width: 100%; border-collapse: collapse; }
+th, td { border: 1px solid #000; padding: 4px; }
+th { background: #eee; }
+</style>
+</head>
+<body>
+<h2>Recibo de Venta</h2>
+<table>
+  <thead>
+    <tr>
+      <th>Prenda</th>
+      <th>Colegio</th>
+      <th>Cantidad</th>
+      <th>Precio</th>
+      <th>Subtotal</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for v in ventas %}
+    <tr>
+      <td>{{ v.nombre }}</td>
+      <td>{{ v.colegio }}</td>
+      <td>{{ v.cantidad }}</td>
+      <td>{{ '%.2f'|format(v.precio) }}</td>
+      <td>{{ '%.2f'|format(v.subtotal) }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+<p>Subtotal: ${{ '%.2f'|format(total) }}</p>
+{% if aplicar_iva %}
+<p>IVA (19%): ${{ '%.2f'|format(iva) }}</p>
+<p><strong>Total: ${{ '%.2f'|format(total_final) }}</strong></p>
+{% else %}
+<p><strong>Total: ${{ '%.2f'|format(total) }}</strong></p>
+{% endif %}
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python-multipart
 
 flask
 mysql-connector-python
+xhtml2pdf


### PR DESCRIPTION
## Summary
- add xhtml2pdf dependency
- support calculating optional 19% IVA in sales
- store sale summary in session
- provide PDF download of sale receipt
- update templates for IVA controls and totals

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -q -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68780406d77c833082050e289cbc1a61