### PR TITLE
Agregar formato COP y total en ventas

### DIFF
--- a/inventario/templates/dashboard.html
+++ b/inventario/templates/dashboard.html
@@ -31,7 +31,7 @@
       <td>{{ p.genero }}</td>
       <td>{{ p.talla }}</td>
       <td>{{ p.cantidad }}</td>
-      <td>{{ "%.2f"|format(p.precio) }}</td>
+      <td>{{ p.precio|cop }}</td>
       <td>
         <a href="{{ url_for('editar', id=p.id) }}" class="btn btn-sm btn-primary">Editar</a>
         {% if session.get('role') == 'admin' %}

--- a/inventario/templates/nueva_venta.html
+++ b/inventario/templates/nueva_venta.html
@@ -102,9 +102,9 @@ function actualizarTotal() {
   const aplicarIVA = document.getElementById('aplicar_iva').checked;
   const iva = aplicarIVA ? total * 0.19 : 0;
   const totalFinal = total + iva;
-  document.getElementById('total').innerText = total.toFixed(2);
-  document.getElementById('iva').innerText = iva.toFixed(2);
-  document.getElementById('total-final').innerText = totalFinal.toFixed(2);
+  document.getElementById('total').innerText = total.toLocaleString('es-CO', { style: 'currency', currency: 'COP' });
+  document.getElementById('iva').innerText = iva.toLocaleString('es-CO', { style: 'currency', currency: 'COP' });
+  document.getElementById('total-final').innerText = totalFinal.toLocaleString('es-CO', { style: 'currency', currency: 'COP' });
   document.getElementById('items').value = JSON.stringify(items);
   console.log("Items actuales:", items);
 }
@@ -133,7 +133,7 @@ document.getElementById('add-btn').addEventListener('click', function(e) {
 
   const tbody = document.getElementById('lista-venta');
   const row = document.createElement('tr');
-  row.innerHTML = `<td>${prod.nombre}</td><td>${prod.colegio}</td><td>${cantidad}</td><td>${precio.toFixed(2)}</td><td>${subtotal.toFixed(2)}</td>`;
+  row.innerHTML = `<td>${prod.nombre}</td><td>${prod.colegio}</td><td>${cantidad}</td><td>${precio.toLocaleString('es-CO', { style: 'currency', currency: 'COP' })}</td><td>${subtotal.toLocaleString('es-CO', { style: 'currency', currency: 'COP' })}</td>`;
   tbody.appendChild(row);
 
   items.push({id: id, cantidad: cantidad});

--- a/inventario/templates/recibo.html
+++ b/inventario/templates/recibo.html
@@ -7,8 +7,8 @@
     <p><strong>ID Venta:</strong> {{ venta.id }}</p>
     <p><strong>Producto:</strong> {{ venta.nombre }}</p>
     <p><strong>Cantidad:</strong> {{ venta.cantidad }}</p>
-    <p><strong>Precio Unitario:</strong> {{ venta.precio }}</p>
-    <p><strong>Total:</strong> {{ venta.cantidad * venta.precio }}</p>
+    <p><strong>Precio Unitario:</strong> {{ venta.precio|cop }}</p>
+    <p><strong>Total:</strong> {{ (venta.cantidad * venta.precio)|cop }}</p>
     <p><strong>Fecha:</strong> {{ venta.fecha }}</p>
     <p><strong>Vendido por:</strong> {{ venta.usuario }}</p>
   </div>

--- a/inventario/templates/recibo_venta.html
+++ b/inventario/templates/recibo_venta.html
@@ -18,18 +18,18 @@
       <td>{{ v.nombre }}</td>
       <td>{{ v.colegio }}</td>
       <td>{{ v.cantidad }}</td>
-      <td>{{ '%.2f'|format(v.precio) }}</td>
-      <td>{{ '%.2f'|format(v.subtotal) }}</td>
+      <td>{{ v.precio|cop }}</td>
+      <td>{{ v.subtotal|cop }}</td>
     </tr>
     {% endfor %}
   </tbody>
 </table>
-<h4>Subtotal: ${{ '%.2f'|format(total) }}</h4>
+<h4>Subtotal: {{ total|cop }}</h4>
 {% if aplicar_iva %}
-<h4>IVA (19%): ${{ '%.2f'|format(iva) }}</h4>
-<h4>Total: ${{ '%.2f'|format(total_final) }}</h4>
+<h4>IVA (19%): {{ iva|cop }}</h4>
+<h4>Total: {{ total_final|cop }}</h4>
 {% else %}
-<h4>Total: ${{ '%.2f'|format(total) }}</h4>
+<h4>Total: {{ total|cop }}</h4>
 {% endif %}
 <a href="{{ url_for('recibo_pdf') }}" class="btn btn-secondary mt-3">Descargar PDF</a>
 <a href="{{ url_for('dashboard') }}" class="btn btn-primary mt-3">Aceptar</a>

--- a/inventario/templates/recibo_venta_pdf.html
+++ b/inventario/templates/recibo_venta_pdf.html
@@ -27,18 +27,18 @@ th { background: #eee; }
       <td>{{ v.nombre }}</td>
       <td>{{ v.colegio }}</td>
       <td>{{ v.cantidad }}</td>
-      <td>{{ '%.2f'|format(v.precio) }}</td>
-      <td>{{ '%.2f'|format(v.subtotal) }}</td>
+      <td>{{ v.precio|cop }}</td>
+      <td>{{ v.subtotal|cop }}</td>
     </tr>
   {% endfor %}
   </tbody>
 </table>
-<p>Subtotal: ${{ '%.2f'|format(total) }}</p>
+<p>Subtotal: {{ total|cop }}</p>
 {% if aplicar_iva %}
-<p>IVA (19%): ${{ '%.2f'|format(iva) }}</p>
-<p><strong>Total: ${{ '%.2f'|format(total_final) }}</strong></p>
+<p>IVA (19%): {{ iva|cop }}</p>
+<p><strong>Total: {{ total_final|cop }}</strong></p>
 {% else %}
-<p><strong>Total: ${{ '%.2f'|format(total) }}</strong></p>
+<p><strong>Total: {{ total|cop }}</strong></p>
 {% endif %}
 </body>
 </html>

--- a/inventario/templates/reportes.html
+++ b/inventario/templates/reportes.html
@@ -9,7 +9,7 @@
   </thead>
   <tbody>
     {% for r in diarios %}
-    <tr><td>{{ r.dia }}</td><td>{{ r.total }}</td></tr>
+    <tr><td>{{ r.dia }}</td><td>{{ r.total|cop }}</td></tr>
     {% endfor %}
   </tbody>
 </table>
@@ -20,7 +20,7 @@
   </thead>
   <tbody>
     {% for r in semanal %}
-    <tr><td>{{ r.year }}</td><td>{{ r.semana }}</td><td>{{ r.total }}</td></tr>
+    <tr><td>{{ r.year }}</td><td>{{ r.semana }}</td><td>{{ r.total|cop }}</td></tr>
     {% endfor %}
   </tbody>
 </table>
@@ -31,7 +31,7 @@
   </thead>
   <tbody>
     {% for r in mensual %}
-    <tr><td>{{ r.mes }}</td><td>{{ r.total }}</td></tr>
+    <tr><td>{{ r.mes }}</td><td>{{ r.total|cop }}</td></tr>
     {% endfor %}
   </tbody>
 </table>

--- a/inventario/templates/ventas.html
+++ b/inventario/templates/ventas.html
@@ -2,6 +2,8 @@
 {% block title %}Ventas{% endblock %}
 {% block content %}
 <h2 class="mb-3">Historial de Ventas</h2>
+{% for colegio, items in ventas|groupby('colegio') %}
+<h4 class="mt-4">{{ colegio }}</h4>
 <table class="table table-striped">
   <thead>
     <tr>
@@ -9,19 +11,24 @@
       <th>Producto</th>
       <th>Usuario</th>
       <th>Cantidad</th>
+      <th>Precio</th>
+      <th>Valor</th>
       <th>Fecha</th>
     </tr>
   </thead>
   <tbody>
-    {% for v in ventas %}
+    {% for v in items %}
     <tr>
       <td>{{ v.id }}</td>
       <td>{{ v.nombre }}</td>
       <td>{{ v.usuario }}</td>
       <td>{{ v.cantidad }}</td>
+      <td>{{ v.precio|cop }}</td>
+      <td>{{ v.valor|cop }}</td>
       <td>{{ v.fecha }}</td>
     </tr>
     {% endfor %}
   </tbody>
 </table>
+{% endfor %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- format currency values in COP across templates
- add custom 'cop' filter for Jinja2
- display sale value in ventas grouped by colegio
- show currency formatting in JS totals

## Testing
- `python -m py_compile inventario/app_flask_inventario.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68785c1486988330b517033d8d6af99f