### PR TITLE
Add client selection and email receipt

### DIFF
--- a/inventario/templates/nueva_venta.html
+++ b/inventario/templates/nueva_venta.html
@@ -7,6 +7,20 @@
 <form method="post" action="{{ url_for('nueva_venta') }}" id="venta-form">
   <div class="row">
     <div class="col-md-6 mb-3">
+      <label class="form-label">Cliente</label>
+      <select name="cliente_id" id="cliente_id" class="form-select" required>
+        <option value="">Seleccione un cliente</option>
+        {% for c in clientes %}
+        <option value="{{ c.id }}">{{ c.nombre }} {{ c.apellido }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="col-md-6 mb-3 d-flex align-items-end">
+      <a href="{{ url_for('listar_clientes') }}" class="btn btn-outline-secondary">Crear cliente</a>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-6 mb-3">
       <label class="form-label">Colegio</label>
       <select id="colegio" class="form-select">
         {% for c in colegios %}

--- a/inventario/templates/recibo_venta.html
+++ b/inventario/templates/recibo_venta.html
@@ -2,6 +2,7 @@
 {% block title %}Recibo de Venta{% endblock %}
 {% block content %}
 <h2 class="mb-3">Recibo de Venta</h2>
+<p><strong>Cliente:</strong> {{ cliente.nombre }} {{ cliente.apellido }} - {{ cliente.email }}</p>
 <table class="table table-striped">
   <thead>
     <tr>
@@ -32,5 +33,6 @@
 <h4>Total: {{ total|cop }}</h4>
 {% endif %}
 <a href="{{ url_for('recibo_pdf') }}" class="btn btn-secondary mt-3">Descargar PDF</a>
+<a href="{{ url_for('enviar_recibo') }}" class="btn btn-secondary mt-3">Enviar por email</a>
 <a href="{{ url_for('dashboard') }}" class="btn btn-primary mt-3">Aceptar</a>
 {% endblock %}

--- a/inventario/templates/recibo_venta_pdf.html
+++ b/inventario/templates/recibo_venta_pdf.html
@@ -11,6 +11,7 @@ th { background: #eee; }
 </head>
 <body>
 <h2>Recibo de Venta</h2>
+<p><strong>Cliente:</strong> {{ cliente.nombre }} {{ cliente.apellido }} - {{ cliente.email }}</p>
 <table>
   <thead>
     <tr>

--- a/schema.sql
+++ b/schema.sql
@@ -24,9 +24,11 @@ CREATE TABLE IF NOT EXISTS ventas (
     id INT AUTO_INCREMENT PRIMARY KEY,
     producto_id INT NOT NULL,
     usuario VARCHAR(50) NOT NULL,
+    cliente_id INT NOT NULL,
     cantidad INT NOT NULL,
     fecha DATETIME NOT NULL,
-    FOREIGN KEY (producto_id) REFERENCES productos(id)
+    FOREIGN KEY (producto_id) REFERENCES productos(id),
+    FOREIGN KEY (cliente_id) REFERENCES clientes(id)
 );
 
 CREATE TABLE IF NOT EXISTS colegios (


### PR DESCRIPTION
## Summary
- allow selecting a client when creating a sale
- include client in sale receipt
- send PDF receipt to client email

## Testing
- `python -m py_compile inventario/app_flask_inventario.py`

------
https://chatgpt.com/codex/tasks/task_e_68786c90ab8083309e9b371a3bd6003a