### PR TITLE
Add admin configurable branding

### DIFF
--- a/inventario/static/css/style.css
+++ b/inventario/static/css/style.css
@@ -6,10 +6,5 @@ a.navbar-brand {
     font-weight: bold;
 }
 .btn-primary {
-    background-color: #dc3545;
-    border-color: #dc3545;
-}
-.btn-primary:hover {
-    background-color: #bd2130;
-    border-color: #bd2130;
+    color: #fff;
 }

--- a/inventario/templates/base.html
+++ b/inventario/templates/base.html
@@ -3,14 +3,25 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{% block title %}Inventario Kansas Sport{% endblock %}</title>
+<title>{% block title %}{{ configuracion.nombre_empresa or 'Inventario' }}{% endblock %}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+    <style>
+      .btn-primary {
+        background-color: {{ configuracion.color_primario }};
+        border-color: {{ configuracion.color_primario }};
+      }
+    </style>
 </head>
 <body>
-<nav class="navbar navbar-expand-lg navbar-dark bg-danger">
+<nav class="navbar navbar-expand-lg navbar-dark" style="background-color: {{ configuracion.color_primario }};">
   <div class="container-fluid">
-    <a class="navbar-brand" href="{{ url_for('dashboard') }}">Kansas Sport</a>
+    <a class="navbar-brand" href="{{ url_for('dashboard') }}">
+      {% if configuracion.logo %}
+        <img src="/{{ configuracion.logo }}" alt="logo" height="30" class="d-inline-block align-text-top">
+      {% endif %}
+      {{ configuracion.nombre_empresa or 'Kansas Sport' }}
+    </a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
@@ -38,6 +49,9 @@
         {% if session.get('role') == 'admin' %}
         <li class="nav-item">
           <a class="nav-link" href="{{ url_for('gestionar_usuarios') }}">Usuarios</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('configuracion') }}">Configuración</a>
         </li>
         {% endif %}
         <li class="nav-item">

--- a/inventario/templates/configuracion.html
+++ b/inventario/templates/configuracion.html
@@ -1,0 +1,41 @@
+{% extends 'base.html' %}
+{% block title %}Configuración{% endblock %}
+{% block content %}
+<h2>Configuración de la Empresa</h2>
+<form method="post" enctype="multipart/form-data">
+  <div class="row mb-3">
+    <div class="col-md-6">
+      <label class="form-label">Nombre</label>
+      <input type="text" name="nombre_empresa" value="{{ config.nombre_empresa or '' }}" class="form-control">
+    </div>
+    <div class="col-md-6">
+      <label class="form-label">Dirección</label>
+      <input type="text" name="direccion" value="{{ config.direccion or '' }}" class="form-control">
+    </div>
+  </div>
+  <div class="row mb-3">
+    <div class="col-md-6">
+      <label class="form-label">Teléfono</label>
+      <input type="text" name="telefono" value="{{ config.telefono or '' }}" class="form-control">
+    </div>
+    <div class="col-md-6">
+      <label class="form-label">Email</label>
+      <input type="email" name="email" value="{{ config.email or '' }}" class="form-control">
+    </div>
+  </div>
+  <div class="row mb-3">
+    <div class="col-md-6">
+      <label class="form-label">Color principal</label>
+      <input type="color" name="color_primario" value="{{ config.color_primario or '#dc3545' }}" class="form-control form-control-color">
+    </div>
+    <div class="col-md-6">
+      <label class="form-label">Logo</label>
+      <input type="file" name="logo" class="form-control">
+      {% if config.logo %}
+      <img src="/{{ config.logo }}" alt="logo" class="mt-2" height="60">
+      {% endif %}
+    </div>
+  </div>
+  <button class="btn btn-primary" type="submit">Guardar</button>
+</form>
+{% endblock %}

--- a/schema.sql
+++ b/schema.sql
@@ -47,3 +47,14 @@ CREATE TABLE IF NOT EXISTS clientes (
     telefono VARCHAR(20),
     email VARCHAR(100)
 );
+
+CREATE TABLE IF NOT EXISTS configuracion (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    nombre_empresa VARCHAR(100),
+    direccion VARCHAR(200),
+    telefono VARCHAR(50),
+    email VARCHAR(100),
+    logo VARCHAR(200),
+    color_primario VARCHAR(20) DEFAULT '#dc3545',
+    color_secundario VARCHAR(20)
+);


### PR DESCRIPTION
## Summary
- create configuration table for company settings
- add routes and templates for admins to manage branding
- display configurable logo, name and colors in the UI

## Testing
- `python -m py_compile inventario/app_flask_inventario.py`

------
https://chatgpt.com/codex/tasks/task_e_6878723169b88330b1224ef7e6268a27