### PR TITLE
Improve login page design

### DIFF
--- a/inventario/static/css/style.css
+++ b/inventario/static/css/style.css
@@ -8,3 +8,16 @@ a.navbar-brand {
 .btn-primary {
     color: #fff;
 }
+
+body.bg-light {
+    background-color: #f0f2f5 !important;
+}
+
+.login-page {
+    min-height: 100vh;
+}
+
+.login-page .card {
+    border: none;
+    border-radius: 1rem;
+}

--- a/inventario/templates/base.html
+++ b/inventario/templates/base.html
@@ -13,7 +13,8 @@
       }
     </style>
 </head>
-<body>
+<body class="{% block body_class %}{% endblock %}">
+{% block navbar %}
 <nav class="navbar navbar-expand-lg navbar-dark" style="background-color: {{ configuracion.color_primario }};">
   <div class="container-fluid">
     <a class="navbar-brand" href="{{ url_for('dashboard') }}">
@@ -62,6 +63,7 @@
     </div>
   </div>
 </nav>
+{% endblock %}
 <div class="container mt-4">
     {% with messages = get_flashed_messages(with_categories=true) %}
       {% if messages %}

--- a/inventario/templates/login.html
+++ b/inventario/templates/login.html
@@ -1,20 +1,26 @@
 {% extends 'base.html' %}
 {% block title %}Login{% endblock %}
+{% block body_class %}bg-light d-flex align-items-center login-page{% endblock %}
+{% block navbar %}{% endblock %}
 {% block content %}
-<div class="row justify-content-center">
-  <div class="col-md-4">
-    <h2 class="mb-3 text-center">Iniciar Sesión</h2>
-    <form method="post">
-      <div class="mb-3">
-        <label for="username" class="form-label">Usuario</label>
-        <input type="text" class="form-control" id="username" name="username" required>
+<div class="container">
+  <div class="row justify-content-center w-100">
+    <div class="col-sm-8 col-md-6 col-lg-4">
+      <div class="card shadow-sm p-4">
+        <h2 class="mb-4 text-center">Iniciar Sesión</h2>
+        <form method="post">
+          <div class="mb-3">
+            <label for="username" class="form-label">Usuario</label>
+            <input type="text" class="form-control" id="username" name="username" required>
+          </div>
+          <div class="mb-3">
+            <label for="password" class="form-label">Contraseña</label>
+            <input type="password" class="form-control" id="password" name="password" required>
+          </div>
+          <button type="submit" class="btn btn-primary w-100">Entrar</button>
+        </form>
       </div>
-      <div class="mb-3">
-        <label for="password" class="form-label">Contraseña</label>
-        <input type="password" class="form-control" id="password" name="password" required>
-      </div>
-      <button type="submit" class="btn btn-primary w-100">Entrar</button>
-    </form>
+    </div>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- added navbar and body class blocks to base template so pages can customize layout
- redesigned login page with centered card layout and no navigation bar
- updated CSS for modern login styling

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68787b0df5ec8330882a80bfed576c5f