### PR TITLE
Add detailed sales reports and Excel export

### DIFF
--- a/inventario/templates/reportes.html
+++ b/inventario/templates/reportes.html
@@ -2,6 +2,7 @@
 {% block title %}Reportes de Ventas{% endblock %}
 {% block content %}
 <h2 class="mb-3">Reportes de Ventas</h2>
+<a href="{{ url_for('exportar_excel_reportes') }}" class="btn btn-primary mb-3">Exportar a Excel</a>
 <h4>Diario</h4>
 <table class="table table-striped mb-4">
   <thead>
@@ -32,6 +33,28 @@
   <tbody>
     {% for r in mensual %}
     <tr><td>{{ r.mes }}</td><td>{{ r.total|cop }}</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+<h4>Por Usuario</h4>
+<table class="table table-striped mb-4">
+  <thead>
+    <tr><th>Usuario</th><th>Total</th></tr>
+  </thead>
+  <tbody>
+    {% for r in por_usuario %}
+    <tr><td>{{ r.usuario }}</td><td>{{ r.total|cop }}</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+<h4>Por Colegio</h4>
+<table class="table table-striped mb-4">
+  <thead>
+    <tr><th>Colegio</th><th>Total</th></tr>
+  </thead>
+  <tbody>
+    {% for r in por_colegio %}
+    <tr><td>{{ r.colegio }}</td><td>{{ r.total|cop }}</td></tr>
     {% endfor %}
   </tbody>
 </table>

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ python-multipart
 flask
 mysql-connector-python
 xhtml2pdf
+openpyxl


### PR DESCRIPTION
## Summary
- track sales by user and by school
- export full sales reports to Excel
- show export button in report view
- add `openpyxl` dependency for Excel creation

## Testing
- `pytest -q`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68790b8ff0848330b40f73c30b6346cd